### PR TITLE
Ensure pnpm is activated via Corepack in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,19 +19,13 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
 
-      - name: Enable Corepack (uses version from package.json)
-        run: corepack enable
+      - name: Enable pnpm via Corepack
+        run: corepack prepare pnpm@9 --activate
 
-      - name: Install deps (frozen)
-        run: pnpm install --frozen-lockfile
-
-      # Escolha seu gerenciador de pacotes. Exemplo com pnpm:
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Install deps
-        run: pnpm i --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Typecheck & Lint
         run: pnpm typecheck && pnpm lint || true  # não falha o deploy se houver aviso


### PR DESCRIPTION
## Summary
- enable pnpm through `corepack prepare` so the CLI is guaranteed to exist on the runner
- add the lockfile path to the Node setup cache configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e44e6753108333a9f9e0f717c88e7e