### PR TITLE
Fix pnpm setup in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,14 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+          run_install: false
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
-
-      - name: Enable pnpm via Corepack
-        run: corepack prepare pnpm@9 --activate
 
       - name: Install deps
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- install pnpm using pnpm/action-setup before configuring Node
- keep pnpm cache configuration without triggering missing executable errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4511fc88083338486fe84dfbe83ab